### PR TITLE
Reformat test output

### DIFF
--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -121,6 +121,7 @@ MAC Address: 9A:02:57:1E:8F:01 (Unknown)
 Firmware test complete
 --------------------
 RESULT skip security.firmware Could not retrieve a firmware version with nmap. Bacnet port could be closed or filtered
+
 ```
 
 ## Module switch

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -64,13 +64,13 @@ Overall device result FAIL
 |pass|base.target.ping|Connectivity|Required|target|
 |skip|cloud.udmi.pointset|Other|Other|No device id.|
 |fail|connection.mac_oui|Other|Other||
-|skip|connection.port_duplex|Other|Other||
-|skip|connection.port_link|Other|Other||
-|skip|connection.port_speed|Other|Other||
+|skip|connection.port_duplex|Other|Other|No local IP|
+|skip|connection.port_link|Other|Other|No local IP|
+|skip|connection.port_speed|Other|Other|No local IP|
 |fail|network.brute|Security|Required||
-|skip|poe.negotiation|Other|Other||
-|skip|poe.power|Other|Other||
-|skip|poe.support|Other|Other||
+|skip|poe.negotiation|Other|Other|No local IP|
+|skip|poe.power|Other|Other|No local IP|
+|skip|poe.support|Other|Other|No local IP|
 |skip|protocol.bacnet.pic|Other|Other|Bacnet device not found... Pics check cannot be performed.|
 |skip|protocol.bacnet.version|Other|Other|Bacnet device not found.|
 |skip|security.firmware|Other|Other|Could not retrieve a firmware version with nmap. Bacnet port could be closed or filtered|
@@ -127,13 +127,60 @@ RESULT skip security.firmware Could not retrieve a firmware version with nmap. B
 ## Module switch
 
 ```
+--------------------
+connection.port_link
+--------------------
+description
+--------------------
 LOCAL_IP not configured, assuming no network switch.
-RESULT skip connection.port_link
-RESULT skip connection.port_speed
-RESULT skip connection.port_duplex
-RESULT skip poe.power
-RESULT skip poe.negotiation
-RESULT skip poe.support
+--------------------
+RESULT skip connection.port_link No local IP
+
+--------------------
+connection.port_speed
+--------------------
+description
+--------------------
+LOCAL_IP not configured, assuming no network switch.
+--------------------
+RESULT skip connection.port_speed No local IP
+
+--------------------
+connection.port_duplex
+--------------------
+description
+--------------------
+LOCAL_IP not configured, assuming no network switch.
+--------------------
+RESULT skip connection.port_duplex No local IP
+
+--------------------
+poe.power
+--------------------
+description
+--------------------
+LOCAL_IP not configured, assuming no network switch.
+--------------------
+RESULT skip poe.power No local IP
+
+--------------------
+poe.negotiation
+--------------------
+description
+--------------------
+LOCAL_IP not configured, assuming no network switch.
+--------------------
+RESULT skip poe.negotiation No local IP
+
+--------------------
+poe.support
+--------------------
+description
+--------------------
+LOCAL_IP not configured, assuming no network switch.
+--------------------
+RESULT skip poe.support No local IP
+
 ```
 
 ## Module macoui
@@ -161,7 +208,15 @@ RESULT skip security.x509
 ## Module udmi
 
 ```
-RESULT skip cloud.udmi.pointset No device id.
+--------------------
+cloud.udmi.pointset
+--------------------
+Validates the payloads from the DUT to a predefined schema
+--------------------
+Device id is null, skipping.
+--------------------
+RESULT skip cloud.udmi.pointset No device id
+
 ```
 
 ## Report complete

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -118,7 +118,6 @@ Automatic bacnet firmware scan using nmap
 PORT      STATE  SERVICE
 47808/udp closed bacnet
 MAC Address: 9A:02:57:1E:8F:01 (Unknown)
-Firmware test complete
 --------------------
 RESULT skip security.firmware Could not retrieve a firmware version with nmap. Bacnet port could be closed or filtered
 

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -62,7 +62,7 @@ Overall device result FAIL
 |---|---|---|---|---|
 |skip|base.switch.ping|Other|Other||
 |pass|base.target.ping|Connectivity|Required|target|
-|skip|cloud.udmi.pointset|Other|Other|No device id.|
+|skip|cloud.udmi.pointset|Other|Other|No device id|
 |fail|connection.mac_oui|Other|Other||
 |skip|connection.port_duplex|Other|Other|No local IP|
 |skip|connection.port_link|Other|Other|No local IP|

--- a/subset/cloud/Dockerfile.test_udmi
+++ b/subset/cloud/Dockerfile.test_udmi
@@ -12,6 +12,7 @@ RUN validator/bin/build
 
 COPY schemas/udmi/ schemas/udmi/
 
+COPY subset/helpers/reporting_utils .
 COPY subset/cloud/test_udmi .
 
 CMD ./test_udmi

--- a/subset/cloud/test_udmi
+++ b/subset/cloud/test_udmi
@@ -2,6 +2,10 @@
 source reporting_utils
 
 REPORT=/tmp/report.txt
+TEST_NAME="cloud.udmi.pointset"
+TEST_DESCRIPTION="Validates the payloads from the DUT to a predefined schema"
+TEST_SUMMARY=""
+LOG=/tmp/udmi.log
 
 # Necessary to reach gcp. Should be done by framework but this works for now.
 route add default gw $GATEWAY_IP
@@ -14,13 +18,22 @@ device_id=`jq -r .device_id /config/device/module_config.json`
 
 if [ "$device_id" == null ]; then
     echo Device id is null, skipping.
-    echo RESULT skip cloud.udmi.pointset No device id. | tee -a $REPORT
+    RESULT_AND_SUMMARY="RESULT skip $TEST_NAME No device id"
+    write_out_result $REPORT \
+                     "$TEST_NAME" \
+                     "$TEST_DESCRIPTION" \
+                     "Device id is null, skipping." \
+                     "$RESULT_AND_SUMMARY"
     exit 0
 fi
 
 if [ ! -f $gcp_cred ]; then
-    echo Missing $gcp_cred file, skipping udmi validation. | tee -a $REPORT
-    echo RESULT skip cloud.udmi.pointset No credentials. | tee -a $REPORT
+    RESULT_AND_SUMMARY="RESULT skip $TEST_NAME No credentials."
+    write_out_result $REPORT \
+                     "$TEST_NAME" \
+                     "$TEST_DESCRIPTION" \
+                     "Missing $gcp_cred file, skipping udmi validation." \
+                     "$RESULT_AND_SUMMARY"
     exit 0
 fi
 
@@ -55,8 +68,10 @@ else
     detail="No result found"
 fi
 
+RESULT_AND_SUMMARY="RESULT $result $TEST_NAME $detail"
+
 write_out_result $REPORT \
-                 "cloud.udmi.pointset" \
-                 "Validates the payloads from the DUT to a predefined schema" \
-                 "see activate.log for more details" \
-                 "RESULT $result cloud.udmi.pointset $detail"
+                 "$TEST_NAME" \
+                 "$TEST_DESCRIPTION" \
+                 "See activate.log for more details" \
+                 "$RESULT_AND_SUMMARY"

--- a/subset/cloud/test_udmi
+++ b/subset/cloud/test_udmi
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+source reporting_utils
 
 REPORT=/tmp/report.txt
 
@@ -54,4 +55,8 @@ else
     detail="No result found"
 fi
 
-echo RESULT $result cloud.udmi.pointset $detail | tee -a $REPORT
+write_out_result $REPORT \
+                 "cloud.udmi.pointset" \
+                 "Validates the payloads from the DUT to a predefined schema" \
+                 "see activate.log for more details" \
+                 "RESULT $result cloud.udmi.pointset $detail"

--- a/subset/helpers/.gitignore
+++ b/subset/helpers/.gitignore
@@ -1,0 +1,1 @@
+/scratch

--- a/subset/helpers/reporting_utils
+++ b/subset/helpers/reporting_utils
@@ -1,0 +1,19 @@
+function write_out_result {
+    REPORT=$1
+    TEST_NAME=$2
+    TEST_DESCRIPTION=$3
+    LOG=$4
+    RESULT_AND_SUMMARY=$5
+
+    cat <<EOF > $REPORT
+--------------------
+$TEST_NAME
+--------------------
+$TEST_DESCRIPTION
+--------------------
+$LOG
+--------------------
+$RESULT_AND_SUMMARY
+
+EOF
+}

--- a/subset/helpers/reporting_utils
+++ b/subset/helpers/reporting_utils
@@ -5,7 +5,7 @@ function write_out_result {
     LOG=$4
     RESULT_AND_SUMMARY=$5
 
-    cat <<EOF > $REPORT
+    cat <<END >> $REPORT
 --------------------
 $TEST_NAME
 --------------------
@@ -15,5 +15,5 @@ $LOG
 --------------------
 $RESULT_AND_SUMMARY
 
-EOF
+END
 }

--- a/subset/helpers/sample_test_output.json
+++ b/subset/helpers/sample_test_output.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "something.test",
+        "description": "informative description",
+        "log": "what happened",
+        "result": "RESULT pass something.test summary goes here"
+    },
+    {
+        "name": "something.else.test",
+        "description": "another informative description",
+        "log": "what happened afterwards, it was bad",
+        "result": "RESULT fail something.else.test summary goes here"
+    }
+]

--- a/subset/pentests/Dockerfile.test_discover
+++ b/subset/pentests/Dockerfile.test_discover
@@ -2,6 +2,7 @@ FROM daq/aardvark:latest
 
 RUN $AG update && $AG install nmap netcat jq
 
+COPY subset/helpers/reporting_utils .
 COPY subset/pentests/test_discover .
 
 CMD ./test_discover

--- a/subset/pentests/test_discover
+++ b/subset/pentests/test_discover
@@ -81,13 +81,6 @@ fi
 
 RESULT_AND_SUMMARY="RESULT $result $TEST_NAME $TEST_SUMMARY"
 
-echo 'Before func:'
-echo $REPORT
-echo $TEST_NAME
-echo $TEST_DESCRIPTION
-echo $REDACTED_LOG
-echo $RESULT_AND_SUMMARY
-
 write_out_result $REPORT \
                  "$TEST_NAME" \
                  "$TEST_DESCRIPTION" \

--- a/subset/pentests/test_discover
+++ b/subset/pentests/test_discover
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+source reporting_utils
 
 REPORT=/tmp/report.txt
 CONFIG=/config/device/module_config.json
@@ -66,38 +67,31 @@ else
     fi
 fi
 
-# Report writing
-# Format:
-# --------------------
-# $TEST_NAME
-# --------------------
-# $TEST_DESCRIPTION
-# --------------------
-# $LOG
-# --------------------
-# <RESULT> <result_summary>
-
-cat <<EOF > $REPORT
---------------------
-$TEST_NAME
---------------------
-$TEST_DESCRIPTION
---------------------
-EOF
-
 if [ -f .fail ]; then
     echo Firmware version does not match...
     TEST_SUMMARY="$TEST_SUMMARY Firmware version does not match"
-    echo "$REDACTED_LOG" | tee -a $REPORT
+    echo "$REDACTED_LOG" 
     result=fail
 else
-    echo "$REDACTED_LOG" | tee -a $REPORT
-    echo 'Firmware test complete' | tee -a $REPORT
+    echo "$REDACTED_LOG \nFirmware test complete" 
+    echo 'Firmware test complete' 
 fi
 
-echo '--------------------' | tee -a $REPORT
-echo RESULT $result $TEST_NAME $TEST_SUMMARY | tee -a $REPORT
-
 # Show 'done' rather than an error state for everything except 'fail'
+
+RESULT_AND_SUMMARY="RESULT $result $TEST_NAME $TEST_SUMMARY"
+
+echo 'Before func:'
+echo $REPORT
+echo $TEST_NAME
+echo $TEST_DESCRIPTION
+echo $REDACTED_LOG
+echo $RESULT_AND_SUMMARY
+
+write_out_result $REPORT \
+                 "$TEST_NAME" \
+                 "$TEST_DESCRIPTION" \
+                 "$REDACTED_LOG" \
+                 "$RESULT_AND_SUMMARY"
 
 [ "$result" == pass ] || [ "$result" == info ] || [ "$result" == skip ]

--- a/subset/switches/Dockerfile.test_switch
+++ b/subset/switches/Dockerfile.test_switch
@@ -7,7 +7,8 @@ RUN $AG update && $AG install openjdk-8-jdk git
 
 RUN $AG update && $AG install maven tcpdump jq
 
-COPY subset/switches/ switches/ 
+COPY subset/switches/ switches/
+COPY subset/helpers/reporting_utils .
 
 RUN cd switches && mvn clean compile assembly:single
 

--- a/subset/switches/test_switch
+++ b/subset/switches/test_switch
@@ -1,4 +1,6 @@
 #!/bin/bash -e
+source reporting_utils
+REPORT=/tmp/report.txt
 
 # Setup for accessing control plane switch. If LOCAL_IP is defined, which
 # is the intended local address for this node on the control plane then
@@ -12,11 +14,45 @@ if [ -n "$LOCAL_IP" ]; then
     java -jar switches/target/switchtest-0.0.1-jar-with-dependencies.jar $SWITCH_IP $SWITCH_PORT $POE_ENABLED
     cp -r tmp/report.txt /tmp/report.txt
 else
-    echo LOCAL_IP not configured, assuming no network switch. | tee /tmp/report.txt
-    echo RESULT skip connection.port_link | tee -a /tmp/report.txt
-    echo RESULT skip connection.port_speed | tee -a /tmp/report.txt
-    echo RESULT skip connection.port_duplex | tee -a /tmp/report.txt
-    echo RESULT skip poe.power | tee -a /tmp/report.txt
-    echo RESULT skip poe.negotiation | tee -a /tmp/report.txt
-    echo RESULT skip poe.support | tee -a /tmp/report.txt
+
+    SKIP_REASON="LOCAL_IP not configured, assuming no network switch."
+    RESULT="skip"
+    SUMMARY="No local IP"
+
+    write_out_result $REPORT \
+                     "connection.port_link" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT connection.port_link $SUMMARY"
+
+    write_out_result $REPORT \
+                     "connection.port_speed" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT connection.port_speed $SUMMARY"
+
+    write_out_result $REPORT \
+                     "connection.port_duplex" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT connection.port_duplex $SUMMARY"
+
+    write_out_result $REPORT \
+                     "poe.power" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT poe.power $SUMMARY"
+
+    write_out_result $REPORT \
+                     "poe.negotiation" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT poe.negotiation $SUMMARY"
+
+    write_out_result $REPORT \
+                     "poe.support" \
+                     "description" \
+                     "$SKIP_REASON" \
+                     "RESULT $RESULT poe.support $SUMMARY"
+
 fi

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -37,7 +37,7 @@ function make_pubber {
 EOF
 }
 
-function capture_aux_test_log {
+function capture_aux_test_results {
     module_name=$1
     test_name=$2
     fgrep -h RESULT inst/run-port-*/nodes/$module_name*/tmp/report.txt | tee -a $TEST_RESULTS
@@ -96,11 +96,11 @@ cmd/run -b -s
 
 # Add just the RESULT lines from all aux tests (from all ports, 3 in this case) into a file
 # These ARE the auxiliary tests
-capture_aux_test_log bacext all
-capture_aux_test_log brute all
-capture_aux_test_log macoui all
-capture_aux_test_log tls all
-capture_aux_test_log discover all
+capture_aux_test_results bacext all
+capture_aux_test_results brute all
+capture_aux_test_results macoui all
+capture_aux_test_results tls all
+capture_aux_test_results discover all
 
 # Capture peripheral logs
 more inst/run-port-*/scans/dhcp_triggers.txt | cat


### PR DESCRIPTION
Reformats the ouput for the following modules:

- switch (NB: only the `skip` cases!)
- udmi

The main point of this was to create a generic shell function completely decoupled from the inner workings of tests so the wheel isn't reinvented/squashed and reshaped everywhere

You can see the output [here](https://github.com/arupiot/daq/blob/reformat_test_output/docs/device_report.md) and the function [here](https://github.com/arupiot/daq/blob/reformat_test_output/subset/helpers/reporting_utils)

Bash being bash the indentation is odd but it works as intended